### PR TITLE
hotfix: db config port 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,7 +26,7 @@ import { NewsfeedsModule } from './newsfeeds/newsfeeds.module';
     TypeOrmModule.forRoot({
       type: 'mysql',
       host: 'localhost',
-      port: 3306,
+      port: 3308,
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,


### PR DESCRIPTION
기존에 mysql이 설치되어서 발생하는 충돌을 회피하기 위해 docker에서 port를 3308로 바꾸었지만 app.module의 db config에서 port를 바꾸지 않아서 급히 수정